### PR TITLE
Simplify emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Use redis as pubsub using a simple eventemitter.
 var redis = require('redis-eventemitter');
 
 var pubsub = redis({
-	prefix: 'production:',
 	url: 'redis://myuser:mypass@localhost:6379/'
 	// port: 6379,
 	// host: '127.0.0.1',
@@ -34,24 +33,24 @@ pubsub.emit('myservice:newuser', { id:'a1b2c3', email:'foo@example.com' });
 
 ## API
 
-### .emit(channel, messages...) [publish]
+### .emit(channel, message[, callback]) [publish]
 
 ``` js
 var redis = require('redis-eventemitter');
-var pubsub = redis({ prefix: 'production:', host: 'localhost', port: 6379 });
+var pubsub = redis({ host: 'localhost', port: 6379 });
 
-pubsub.emit('myservice:newuser', { id:'a1b2c3' });
+pubsub.emit('myservice:newuser', JSON.stringify({ id:'a1b2c3' }));
 ```
 
-### .on(pattern, function(channel, messages...) { ... }) [subscribe]
+### .on(pattern, function(channel, message) { ... }) [subscribe]
 
 ``` js
 var redis = require('redis-eventemitter');
-var pubsub = redis({ scope: 'production:', host: 'localhost', port: 6379 });
+var pubsub = redis({ host: 'localhost', port: 6379 });
 
 pubsub.on('*:newuser', function(channel, message) {
 	console.log(channel); // myservice:newuser
-	console.log(message); // { id:'a1b2c3' }
+	console.log(JSON.parse(message)); // { id:'a1b2c3' }
 });
 ```
 
@@ -86,12 +85,6 @@ Url for the redis server.
 ### auth_pass
 
 Password for the redis server. Defaults to not being set.
-
-### prefix
-
-A prefix that is added to the channel name, when publishing events to the redis pubsub. Useful for separating services or environments, e.g. `production`, `development`, and `staging`.
-
-It is also removed when the listeners is invoked.
 
 ### pub
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,23 @@
 # redis-eventemitter [![build status](https://secure.travis-ci.org/freeall/redis-eventemitter.png)](http://travis-ci.org/freeall/redis-eventemitter)
 
-Use redis as pubsub using a simple eventemitter.
+Use redis as pubsub using a simple eventemitter. A thin layer on top of `ioredis`.
 
-	npm install redis-eventemitter
+`$ npm install redis-eventemitter`
 
 ## Usage
 
 ```js
 var redis = require('redis-eventemitter');
 
-var pubsub = redis({
-	url: 'redis://myuser:mypass@localhost:6379/'
-	// port: 6379,
-	// host: '127.0.0.1',
-	// auth_pass: 'mypassword'
-
-	// in case you want to control Redis clients
-	// creation you can specify pub/sub clients pair:
-	// pub: pubClient,
-	// sub: subClient
-});
+var pubsub = redis('redis://myuser:mypass@localhost:6379/')
+// var pubsub = redis({ // If you rediss (tls)
+// 	host: 'localhost',
+//   port: 6379,
+//   password: 'someadminpassword',
+//   tls: {
+//     ca: '-----BEGIN CERTIFICATE-----....',
+//   }
+// });
 
 // Listen for messages on the *:newuser channel
 pubsub.on('*:newuser', function(channel, user) {
@@ -70,26 +68,4 @@ Removes all listeners.
 
 ## Options
 
-### port
-
-Port for the redis server.
-
-### host
-
-Host for the redis server.
-
-### url
-
-Url for the redis server.
-
-### auth_pass
-
-Password for the redis server. Defaults to not being set.
-
-### pub
-
-Redis client instance used for `publish`.
-
-### sub
-
-Redis client instance used for `subscribe`.
+All options are sent directly to the module `ioredis`.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "author": "freeall",
   "dependencies": {
-    "redis": "^2.6.3"
+    "ioredis": "^4.14.0",
+    "redis": "^2.8.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -36,21 +36,10 @@ hub.on('testTwoListeners', expectCall('testTwoListeners', function() { }));
 hub.on('testTwoListeners', expectCall('testTwoListeners', function() { }));
 
 
-/* Test callback */
-hub.on('testCallbackAndArgs', expectCall('testCallbackAndArgs', function(channel, msg) {
-	assert(channel === 'testCallbackAndArgs');
-	assert(msg === 'testArg');
-}));
-
-
 /* Test errors*/
 var testNoMessage = expectCall('testNoMessage', function () { })
-var testCallbackInsteadOfArgs = expectCall('testCallbackInsteadOfArgs', function () { })
-var testCallbackNotAFunction = expectCall('testCallbackNotAFunction', function () { })
 hub.on('error', function (err) {
 	if (err.message === 'Expected both a channel and a message') return testNoMessage()
-	if (err.message === 'Expected a message, but was given a function') return testCallbackInsteadOfArgs()
-	if (err.message === 'Callback is not a function') return testCallbackNotAFunction()
 })
 
 // Wait a second before emitting as there's a small race condition where the listener might not have been registered yet
@@ -62,10 +51,7 @@ setTimeout(function () {
 	hub.emit('testOnce', 'ok');
 	hub.emit('testJson', JSON.stringify({ msg: 'ok' }));
 	hub.emit('testTwoListeners', 'ok');
-	hub.emit('testCallbackAndArgs', 'testArg', expectCall('testCallbackAndArgs', function () { }));
 	hub.emit('testNoMessage')
-	hub.emit('testCallbackInsteadOfArgs', function () { })
-	hub.emit('testCallbackNotAFunction', 'foo', 'bar')
 }, 1000)
 
 setTimeout(function() {

--- a/test.js
+++ b/test.js
@@ -47,14 +47,14 @@ hub.on('testCallbackAndArgs', expectCall('testCallbackAndArgs', function(channel
 var testNoMessage = expectCall('testNoMessage', function () { })
 var testCallbackInsteadOfArgs = expectCall('testCallbackInsteadOfArgs', function () { })
 var testCallbackNotAFunction = expectCall('testCallbackNotAFunction', function () { })
-hub.on('error', err => {
+hub.on('error', function (err) {
 	if (err.message === 'Expected both a channel and a message') return testNoMessage()
 	if (err.message === 'Expected a message, but was given a function') return testCallbackInsteadOfArgs()
 	if (err.message === 'Callback is not a function') return testCallbackNotAFunction()
 })
 
 // Wait a second before emitting as there's a small race condition where the listener might not have been registered yet
-setTimeout(() => {
+setTimeout(function () {
 	hub.emit('testSimple', 'ok');
 	hub.emit('foo:testGlobBefore', 'ok');
 	hub.emit('testGlobAfter:foo', 'ok');

--- a/test.js
+++ b/test.js
@@ -4,11 +4,11 @@ var assert = require('assert');
 var testsMissing = 0;
 var expectCall = function(name, f) {
 	testsMissing++;
-	console.log(`Expect ${name} to be called. Outstanding tests: ${testsMissing}`)
+	console.log('Expect ' + name + ' to be called. Outstanding tests: ' + testsMissing)
 	var count = 1;
 	return function() {
 		testsMissing--;
-		console.log(`${name} was called. Outstanding tests: ${testsMissing}`)
+		console.log(name + ' was called. Outstanding tests: ' + testsMissing)
 		assert(count-- >= 0);
 		f.apply(null, arguments);
 	};


### PR DESCRIPTION
This PR simplifies `redis-eventemitter` by doing a few things:

- No longer checks/stringifies/parses JSON. This was nice, but not great for non-JSON data.
- No longer accept several messages (`.emit('channel', 'msg1', 'msg2'...)`). Simplifies implementation and can be implemented on top.
- `prefix` option has been removed. Was not a good idea.
- Undocumented `.flush(fn)` method has been removed. The idea was to make sure that all emits had been called, but it didn't work, and was probably not useful any way.